### PR TITLE
Expand search for reviewers

### DIFF
--- a/src/lf_workflow_dash/lsdb_interrupts/open_prs.py
+++ b/src/lf_workflow_dash/lsdb_interrupts/open_prs.py
@@ -31,9 +31,15 @@ def get_open_prs(org: str, repos: List[str], token: str) -> List[Dict]:
                 author = pr["user"]["login"] if pr["user"] else "unknown"
 
                 # Reviewers are not returned in the pull request list response. Make a new request.
+                url = f"{GITHUB_API_BASE}/repos/{org}/{repo}/pulls/{pr['number']}/requested_reviewers"
+                requested_reviewers = paginate_github_api(session, url)
+                requested_reviewers = set(person["login"] for person in requested_reviewers[0]["users"])
+
                 url = f"{GITHUB_API_BASE}/repos/{org}/{repo}/pulls/{pr['number']}/reviews"
                 reviewers = paginate_github_api(session, url)
-                reviewers = set(person["user"]["login"] for person in reviewers) - set([author])
+                reviewers = set(person["user"]["login"] for person in reviewers)
+
+                reviewers = reviewers | requested_reviewers - set(author)
                 list(reviewers).sort()
 
                 prs.append(


### PR DESCRIPTION
Closes #78 

https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28

> Once a requested reviewer submits a review, they are no longer considered a requested  reviewer. Their review will instead be returned by the [List reviews for a pull request](https://docs.github.com/rest/pulls/reviews#list-reviews-for-a-pull-request) operation.